### PR TITLE
Project next steps

### DIFF
--- a/RUNTIME_GOLDEN_PATH.md
+++ b/RUNTIME_GOLDEN_PATH.md
@@ -27,6 +27,10 @@ experimental until repaired and re-validated.
   - `pending_review` -> `approved` for accepted outputs
   - `pending_review` -> `requeue` (or `failed` after retry limit) for rejected outputs
   - quality-gate state is mirrored in `quality_gate_queue.json` (`needs_qa` / `rejected`)
+- Tool-first routing lifecycle is now explicit in the worker path:
+  - prompt tasks are routed through `tool_router` before `/grind` LLM dispatch
+  - matched tool context is injected into the prompt for reuse-first execution
+  - route metadata is recorded in execution events (`tool_route`, `tool_name`, `tool_confidence`)
 
 ## Safety and budget guarantees in this path
 
@@ -43,5 +47,5 @@ experimental until repaired and re-validated.
 
 ```bash
 python3 -m py_compile worker.py swarm.py control_panel.py runtime_contract.py
-pytest -q tests/test_runtime_phase0_phase1.py tests/test_runtime_phase2_quality_review.py
+pytest -q tests/test_runtime_phase0_phase1.py tests/test_runtime_phase2_quality_review.py tests/test_runtime_phase3_tool_routing.py
 ```

--- a/VISION_ROADMAP.md
+++ b/VISION_ROADMAP.md
@@ -30,7 +30,7 @@ Cross-repo archaeology and anomaly evidence are tracked in `CROSS_REPO_TIMELINE.
 ## Current hard truths (from code + history)
 
 - Canonical runtime exists (`worker.py` + `swarm.py` + `control_panel.py`), but several advanced modules are not wired into that path.
-- `tool_router.py` currently cannot import expected skill interfaces from `skills/skill_registry.py`.
+- `tool_router.py` now imports cleanly against `skills/skill_registry.py`; next gains should focus on raising tool-hit rate and promotion loops.
 - `swarm_orchestrator_v2.py` and `worker_pool.py` are present but currently not reliable production orchestration code.
 - `quality_gates.py`, `safety_gateway.py`, and `secure_api_wrapper.py` exist and are tested, but not hard-wired into default task execution.
 - Major docs/features were removed in purge commit `4428452`, with a backup snapshot in `5b6a0b6`.

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -7,7 +7,25 @@ library; the minimal version here keeps imports stable and is sufficient for
 tests and basic usage.
 """
 
-from .skill_registry import register_skill, get_skill, list_skills  # noqa: F401
+from .skill_registry import (  # noqa: F401
+    SkillRegistry,
+    compose_skills,
+    decompose_task,
+    find_similar_skills,
+    get_skill,
+    list_skills,
+    register_skill,
+    retrieve_skill,
+)
 
-__all__ = ["register_skill", "get_skill", "list_skills"]
+__all__ = [
+    "SkillRegistry",
+    "register_skill",
+    "get_skill",
+    "list_skills",
+    "find_similar_skills",
+    "retrieve_skill",
+    "compose_skills",
+    "decompose_task",
+]
 

--- a/skills/skill_registry.py
+++ b/skills/skill_registry.py
@@ -1,14 +1,20 @@
 """
-Minimal in-memory skill registry.
+Skill registry with compatibility APIs for tool-first routing.
 
-The repo contains code paths that import `skills.skill_registry` to register and
-retrieve reusable code snippets extracted from successful sessions.
+This module intentionally keeps both:
+1) lightweight module-level helper functions, and
+2) a richer `SkillRegistry` class expected by historical call sites.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from typing import Dict, List, Optional, Sequence
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+import math
+import re
+from typing import Dict, List, Optional, Sequence, Tuple
+
+_TOKEN_RE = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]+")
 
 
 @dataclass(frozen=True)
@@ -16,18 +22,147 @@ class Skill:
     name: str
     code: str
     description: str = ""
-    preconditions: List[str] = None
-    postconditions: List[str] = None
+    preconditions: List[str] = field(default_factory=list)
+    postconditions: List[str] = field(default_factory=list)
+    keywords: List[str] = field(default_factory=list)
 
-    def to_dict(self) -> Dict:
-        d = asdict(self)
-        # Normalize None lists
-        d["preconditions"] = d["preconditions"] or []
-        d["postconditions"] = d["postconditions"] or []
-        return d
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
 
 
 _REGISTRY: Dict[str, Skill] = {}
+_BOOTSTRAPPED_DEFAULTS = False
+
+
+_DEFAULT_SKILLS: Tuple[Dict[str, object], ...] = (
+    {
+        "name": "add_test_coverage",
+        "description": "Generate focused pytest tests for changed behavior.",
+        "code": (
+            "def add_test_coverage(target_module: str) -> str:\n"
+            "    return f\"Add pytest cases for {target_module} edge cases and failures.\""
+        ),
+        "keywords": ["pytest", "test", "coverage", "regression"],
+    },
+    {
+        "name": "read_json_safe",
+        "description": "Read JSON from disk with clear error handling.",
+        "code": (
+            "import json\n"
+            "from pathlib import Path\n\n"
+            "def read_json_safe(path: str):\n"
+            "    p = Path(path)\n"
+            "    return json.loads(p.read_text(encoding='utf-8'))"
+        ),
+        "keywords": ["json", "read", "parse"],
+    },
+    {
+        "name": "write_json_safe",
+        "description": "Write JSON to disk with stable formatting.",
+        "code": (
+            "import json\n"
+            "from pathlib import Path\n\n"
+            "def write_json_safe(path: str, data) -> None:\n"
+            "    p = Path(path)\n"
+            "    p.write_text(json.dumps(data, indent=2), encoding='utf-8')"
+        ),
+        "keywords": ["json", "write", "save"],
+    },
+    {
+        "name": "validate_python_syntax",
+        "description": "Validate Python source code compiles cleanly.",
+        "code": (
+            "def validate_python_syntax(source: str) -> bool:\n"
+            "    compile(source, '<skill>', 'exec')\n"
+            "    return True"
+        ),
+        "keywords": ["python", "syntax", "validate", "compile"],
+    },
+    {
+        "name": "run_command",
+        "description": "Execute a shell command and return status/output.",
+        "code": (
+            "import subprocess\n\n"
+            "def run_command(command: str):\n"
+            "    proc = subprocess.run(command, shell=True, capture_output=True, text=True)\n"
+            "    return {'returncode': proc.returncode, 'stdout': proc.stdout, 'stderr': proc.stderr}"
+        ),
+        "keywords": ["shell", "command", "execute"],
+    },
+    {
+        "name": "safe_dict_get",
+        "description": "Read nested dictionary values safely.",
+        "code": (
+            "def safe_dict_get(data: dict, path, default=None):\n"
+            "    cur = data\n"
+            "    for key in path:\n"
+            "        if not isinstance(cur, dict) or key not in cur:\n"
+            "            return default\n"
+            "        cur = cur[key]\n"
+            "    return cur"
+        ),
+        "keywords": ["dict", "nested", "safe", "get"],
+    },
+)
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token.lower() for token in _TOKEN_RE.findall(text or "")]
+
+
+def _to_vector(text: str) -> Dict[str, float]:
+    tokens = _tokenize(text)
+    if not tokens:
+        return {}
+    counts = Counter(tokens)
+    total = float(sum(counts.values()))
+    return {token: count / total for token, count in counts.items()}
+
+
+def _cosine_similarity(vec_a: Dict[str, float], vec_b: Dict[str, float]) -> float:
+    if not vec_a or not vec_b:
+        return 0.0
+    dot = sum(vec_a.get(token, 0.0) * vec_b.get(token, 0.0) for token in set(vec_a) & set(vec_b))
+    norm_a = math.sqrt(sum(value * value for value in vec_a.values()))
+    norm_b = math.sqrt(sum(value * value for value in vec_b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _skill_text(skill: Skill) -> str:
+    return " ".join(
+        [
+            skill.name,
+            skill.description,
+            " ".join(skill.keywords),
+            " ".join(skill.preconditions),
+            " ".join(skill.postconditions),
+        ]
+    ).strip()
+
+
+def _normalize_terms(values: Optional[Sequence[str]]) -> List[str]:
+    if not values:
+        return []
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def _bootstrap_default_skills() -> None:
+    global _BOOTSTRAPPED_DEFAULTS
+    if _BOOTSTRAPPED_DEFAULTS:
+        return
+    for item in _DEFAULT_SKILLS:
+        name = str(item["name"])
+        if name in _REGISTRY:
+            continue
+        register_skill(
+            name=name,
+            code=str(item["code"]),
+            description=str(item.get("description", "")),
+            keywords=item.get("keywords", []),
+        )
+    _BOOTSTRAPPED_DEFAULTS = True
 
 
 def register_skill(
@@ -36,24 +171,179 @@ def register_skill(
     description: str = "",
     preconditions: Optional[Sequence[str]] = None,
     postconditions: Optional[Sequence[str]] = None,
+    keywords: Optional[Sequence[str]] = None,
 ) -> None:
     """Register or overwrite a skill by name."""
-    _REGISTRY[name] = Skill(
-        name=name,
-        code=code,
-        description=description,
-        preconditions=list(preconditions) if preconditions else [],
-        postconditions=list(postconditions) if postconditions else [],
+    normalized_name = str(name or "").strip()
+    if not normalized_name:
+        raise ValueError("skill name must be non-empty")
+    _REGISTRY[normalized_name] = Skill(
+        name=normalized_name,
+        code=str(code or ""),
+        description=str(description or ""),
+        preconditions=_normalize_terms(preconditions),
+        postconditions=_normalize_terms(postconditions),
+        keywords=_normalize_terms(keywords),
     )
 
 
-def get_skill(name: str) -> Optional[Dict]:
+def get_skill(name: str) -> Optional[Dict[str, object]]:
     """Return a skill dict or None."""
-    skill = _REGISTRY.get(name)
+    skill = _REGISTRY.get(str(name))
     return skill.to_dict() if skill else None
 
 
 def list_skills() -> List[str]:
     """List registered skill names."""
+    _bootstrap_default_skills()
     return sorted(_REGISTRY.keys())
+
+
+def find_similar_skills(
+    query: str,
+    top_k: int = 3,
+    *,
+    min_similarity: float = 0.0,
+) -> List[Tuple[str, float]]:
+    """Return `(skill_name, similarity)` tuples sorted descending."""
+    _bootstrap_default_skills()
+    query_vector = _to_vector(query)
+    if not _REGISTRY:
+        return []
+    scored: List[Tuple[str, float]] = []
+    for name, skill in _REGISTRY.items():
+        score = _cosine_similarity(query_vector, _to_vector(_skill_text(skill)))
+        if score >= min_similarity:
+            scored.append((name, score))
+    scored.sort(key=lambda item: item[1], reverse=True)
+    return scored[: max(0, int(top_k))]
+
+
+def retrieve_skill(task_description: str, min_similarity: float = 0.18) -> Optional[Dict[str, object]]:
+    """Retrieve the single best skill for a task description."""
+    ranked = find_similar_skills(task_description, top_k=1, min_similarity=min_similarity)
+    if ranked:
+        return get_skill(ranked[0][0])
+
+    # Fallback to direct keyword containment when similarity is very low.
+    task_tokens = set(_tokenize(task_description))
+    if not task_tokens:
+        return None
+    for name, skill in _REGISTRY.items():
+        if set(_tokenize(name)) & task_tokens:
+            return skill.to_dict()
+        if set(_tokenize(skill.description)) & task_tokens:
+            return skill.to_dict()
+    return None
+
+
+def compose_skills(skill_names: Sequence[str]) -> Optional[Dict[str, object]]:
+    """
+    Compose multiple registered skills into a combined executable tool payload.
+    """
+    _bootstrap_default_skills()
+    deduped_names: List[str] = []
+    for item in skill_names or []:
+        name = str(item).strip()
+        if name and name not in deduped_names:
+            deduped_names.append(name)
+
+    if not deduped_names:
+        return None
+
+    parts: List[Skill] = [skill for name in deduped_names if (skill := _REGISTRY.get(name))]
+    if not parts:
+        return None
+    if len(parts) == 1:
+        payload = parts[0].to_dict()
+        payload["components"] = [parts[0].name]
+        return payload
+
+    composed_name = "composed_" + "_".join(skill.name for skill in parts[:3])
+    composed_code = "\n\n".join(
+        f"# --- Skill: {skill.name} ---\n{skill.code}".rstrip()
+        for skill in parts
+    )
+    composed_description = "Composed skill pipeline: " + " -> ".join(skill.name for skill in parts)
+    preconditions = [item for skill in parts for item in skill.preconditions]
+    postconditions = [item for skill in parts for item in skill.postconditions]
+    keywords = sorted({token for skill in parts for token in skill.keywords})
+    return {
+        "name": composed_name,
+        "code": composed_code,
+        "description": composed_description,
+        "preconditions": preconditions,
+        "postconditions": postconditions,
+        "keywords": keywords,
+        "components": [skill.name for skill in parts],
+    }
+
+
+def decompose_task(task_description: str, top_k: int = 3) -> List[str]:
+    """Suggest component skills for task decomposition."""
+    ranked = find_similar_skills(task_description, top_k=top_k, min_similarity=0.1)
+    return [name for name, score in ranked if score > 0.0]
+
+
+class SkillRegistry:
+    """
+    Backward-compatible registry wrapper used by router/intent/context modules.
+    """
+
+    def __init__(self) -> None:
+        _bootstrap_default_skills()
+        # Some call sites probe for this attribute before using embeddings.
+        self.vectorizer = None
+
+    def register_skill(
+        self,
+        name: str,
+        code: str,
+        description: str = "",
+        preconditions: Optional[Sequence[str]] = None,
+        postconditions: Optional[Sequence[str]] = None,
+        keywords: Optional[Sequence[str]] = None,
+    ) -> None:
+        register_skill(name, code, description, preconditions, postconditions, keywords)
+
+    def get_skill(self, name: str) -> Optional[Dict[str, object]]:
+        return get_skill(name)
+
+    def list_skills(self) -> List[str]:
+        return list_skills()
+
+    def retrieve_skill(self, task_description: str, min_similarity: float = 0.18) -> Optional[Dict[str, object]]:
+        return retrieve_skill(task_description, min_similarity=min_similarity)
+
+    def find_similar_skills(
+        self,
+        query: str,
+        top_k: int = 3,
+        log_expansion: bool = False,
+    ) -> List[Tuple[str, float]]:
+        # `log_expansion` is accepted for compatibility with context builder.
+        _ = log_expansion
+        return find_similar_skills(query, top_k=top_k, min_similarity=0.0)
+
+    def decompose_task(self, task_description: str, top_k: int = 3) -> List[str]:
+        return decompose_task(task_description, top_k=top_k)
+
+    def compose_skills(self, skill_names: Sequence[str]) -> Optional[Dict[str, object]]:
+        return compose_skills(skill_names)
+
+    def compute_embedding(self, text: str) -> Dict[str, float]:
+        return _to_vector(text)
+
+
+__all__ = [
+    "Skill",
+    "SkillRegistry",
+    "register_skill",
+    "get_skill",
+    "list_skills",
+    "find_similar_skills",
+    "retrieve_skill",
+    "compose_skills",
+    "decompose_task",
+]
 

--- a/tests/test_runtime_phase3_tool_routing.py
+++ b/tests/test_runtime_phase3_tool_routing.py
@@ -1,0 +1,134 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import tool_router
+import worker
+from skills.skill_registry import compose_skills, register_skill
+
+
+class _RouteResult:
+    def __init__(self, tool, route: str, confidence: float):
+        self.tool = tool
+        self.route = route
+        self.confidence = confidence
+
+    @property
+    def found(self) -> bool:
+        return self.tool is not None
+
+
+def test_tool_router_imports_and_routes_exact_skill(tmp_path):
+    register_skill(
+        name="phase3_exact_skill",
+        code="def phase3_exact_skill():\n    return 'ok'",
+        description="Exact route probe for phase 3",
+        keywords=["exact", "phase3"],
+    )
+    store_path = tmp_path / "tool_store.json"
+    store_path.write_text("{}", encoding="utf-8")
+
+    router = tool_router.ToolRouter(tool_store_path=str(store_path))
+    result = router.route("Please run phase3_exact_skill on this task.")
+
+    assert result.found is True
+    assert result.route == "exact"
+    assert result.tool["name"] == "phase3_exact_skill"
+
+
+def test_skill_registry_can_compose_multiple_skills():
+    register_skill(
+        name="phase3_compose_alpha",
+        code="def phase3_compose_alpha(x):\n    return x + 1",
+        description="Alpha compose skill",
+        keywords=["alpha", "compose"],
+    )
+    register_skill(
+        name="phase3_compose_beta",
+        code="def phase3_compose_beta(x):\n    return x * 2",
+        description="Beta compose skill",
+        keywords=["beta", "compose"],
+    )
+
+    composed = compose_skills(["phase3_compose_alpha", "phase3_compose_beta"])
+    assert composed is not None
+    assert composed["name"].startswith("composed_")
+    assert composed["components"] == ["phase3_compose_alpha", "phase3_compose_beta"]
+    assert "Skill: phase3_compose_alpha" in composed["code"]
+    assert "Skill: phase3_compose_beta" in composed["code"]
+
+
+def test_worker_execute_task_injects_tool_context(monkeypatch):
+    captured = {}
+
+    class _StubRouter:
+        def route(self, prompt, context=None):
+            return _RouteResult(
+                tool={
+                    "name": "phase3_injected_tool",
+                    "description": "Reusable helper for routing",
+                    "code": "def phase3_injected_tool():\n    return 'ok'",
+                },
+                route="semantic",
+                confidence=0.91,
+            )
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "result": "done",
+                "model": "llama-3.1-8b-instant",
+                "safety_report": {"passed": True},
+            }
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, json):
+            captured["url"] = url
+            captured["payload"] = json
+            return _FakeResponse()
+
+    monkeypatch.setattr(worker, "WORKER_TOOL_ROUTER", _StubRouter())
+    monkeypatch.setattr(worker, "validate_model_id", lambda _model: None)
+    monkeypatch.setattr(
+        worker,
+        "_run_worker_safety_check",
+        lambda task_id, prompt, command, mode: (
+            True,
+            {"passed": True, "task_id": task_id, "checks": {}},
+        ),
+    )
+    monkeypatch.setattr(worker.httpx, "Client", _FakeClient)
+
+    result = worker.execute_task(
+        {
+            "id": "task_phase3_route",
+            "prompt": "Improve authentication tests",
+            "mode": "llm",
+            "model": "llama-3.1-8b-instant",
+        },
+        api_endpoint="http://127.0.0.1:8420",
+    )
+
+    assert result["status"] == "completed"
+    assert result["tool_route"] == "semantic"
+    assert result["tool_name"] == "phase3_injected_tool"
+    assert result["tool_confidence"] == pytest.approx(0.91)
+    assert captured["url"].endswith("/grind")
+    assert "RELEVANT TOOL CONTEXT" in captured["payload"]["prompt"]
+    assert "phase3_injected_tool" in captured["payload"]["prompt"]
+    assert "TASK:\nImprove authentication tests" in captured["payload"]["prompt"]


### PR DESCRIPTION
## Summary

This PR implements Phase 3 of the roadmap: **tool-first compounding**.

The change restores the full `SkillRegistry` API, integrates a tool router into the canonical `worker.py` execution path, and injects relevant tool context into prompts before LLM generation. This enables the worker to proactively leverage existing skills, improving efficiency and skill utilization.

## Testing

- [x] Tests pass (`pytest`)

## Gatekeeper Checklist

- [ ] I understand this repo requires approval from **@cyberkrunk69**.
- [ ] This change is submitted via a PR (no direct pushes).
- [ ] Any security impact has been considered and documented.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-716390b6-201f-4a8b-80e4-326842f86186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-716390b6-201f-4a8b-80e4-326842f86186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

